### PR TITLE
Added support for parsing specific parts of the DOM

### DIFF
--- a/src/lib/global.js
+++ b/src/lib/global.js
@@ -6,10 +6,11 @@ export function getGlobal() {
     transitions: true,
     actions: {},
     errors: {},
-    parse: function () {
+    parse: function (documentOrNode) {
       // Parse the DOM for zjax elements
-      parseSwaps(document);
-      parseActions(document);
+      documentOrNode = documentOrNode || document;
+      parseSwaps(documentOrNode);
+      parseActions(documentOrNode);
     },
   };
 }


### PR DESCRIPTION
Fixes https://github.com/codepilotsf/zjax/issues/10#issuecomment-3015050452

Sample usage:
```
const button = document.createElement("button");
button.textContent = "Fetch Moby Dick";
button.setAttribute("z-swap", "@click.prevent https://httpbin.org/html *->button");
document.body.appendChild(button);
zjax.parse(button);
```

This also works:
```
const elem = document.getElementById("foo");
const zSwap = "@click.prevent DELETE https://httpbin.org/html *->button";
elem.innerHTML = `
  <button z-swap="${zSwap}">
    DELETE Moby Dick
  </button>
`;
zjax.parse(elem);
```
The request will be correctly sent as a DELETE, not GET